### PR TITLE
Fix reference to Update (Folder) element

### DIFF
--- a/docs/web-service-reference/updatefolder-operation.md
+++ b/docs/web-service-reference/updatefolder-operation.md
@@ -88,7 +88,7 @@ The following elements are used in the request:
     
 - [FolderId](folderid.md)
     
-- [Updates (Item)](updates-item.md)
+- [Updates (Folder)](updates-folder.md)
     
 - [SetFolderField](setfolderfield.md)
     


### PR DESCRIPTION
The UpdateFolder operation referenced the Updates (Item) element instead of the Updates (Folder) element.