### PR TITLE
Added deprecation note as per request by eDiscovery engineering

### DIFF
--- a/docs/web-service-reference/searchmailboxes-operation.md
+++ b/docs/web-service-reference/searchmailboxes-operation.md
@@ -14,6 +14,9 @@ description: "Find information about the SearchMailboxes EWS operation."
 
 # SearchMailboxes operation
 
+> [!NOTE]
+> This operation is deprecated, and no longer supported by Microsoft.  As a replacement, please use the [FindItem](finditem-operation.md) operation.
+
 Find information about the **SearchMailboxes** EWS operation. 
   
 The **SearchMailboxes** operation searches mailboxes for occurrences of terms in mailbox items. 


### PR DESCRIPTION
The eDiscovery engineering team (contacts: mahage and samuelsh) have requested that this note be added to the searchmailboxes-operation.md file. The note states that searchmailboxes operation is deprecated and to use finditems operation instead.