### PR TITLE
Add two missing values to DistinguishedPropertySetId enum

### DIFF
--- a/docs/web-service-reference/extendedfielduri.md
+++ b/docs/web-service-reference/extendedfielduri.md
@@ -43,13 +43,15 @@ The following sections describe attributes, child elements, and parent elements.
 
 |**Value**|**Description**|
 |:-----|:-----|
-|Meeting  <br/> |Identifies the meeting property set ID by name.  <br/> |
-|Appointment  <br/> |Identifies the appointment property set ID by name.  <br/> |
-|Common  <br/> |Identifies the common property set ID by name.  <br/> |
-|PublicStrings  <br/> |Identifies the public strings property set ID by name.  <br/> |
 |Address  <br/> |Identifies the address property set ID by name.  <br/> |
-|InternetHeaders  <br/> |Identifies the Internet headers property set ID by name.  <br/> |
+|Appointment  <br/> |Identifies the appointment property set ID by name.  <br/> |
 |CalendarAssistant  <br/> |Identifies the calendar assistant property set ID by name.  <br/> |
+|Common  <br/> |Identifies the common property set ID by name.  <br/> |
+|InternetHeaders  <br/> |Identifies the Internet headers property set ID by name.  <br/> |
+|Meeting  <br/> |Identifies the meeting property set ID by name.  <br/> |
+|Sharing  <br/> | <br/> |
+|PublicStrings  <br/> |Identifies the public strings property set ID by name.  <br/> |
+|Task  <br/> |Identifies the task property set ID by name.  <br/> |
 |UnifiedMessaging  <br/> |Identifies the unified messaging property set ID by name.  <br/> |
    
 #### PropertyType Attribute


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/dotnet/api/exchangewebservices.distinguishedpropertysettype?view=exchange-ews-proxy, enum values `Sharing` and `Task` are also valid.

While here, sort the enum values.