### PR TITLE
Document that "EX" is also a possible value

### DIFF
--- a/docs/web-service-reference/routingtype-emailaddress.md
+++ b/docs/web-service-reference/routingtype-emailaddress.md
@@ -44,7 +44,12 @@ None.
    
 ## Text value
 
-A text value is optional. The only valid value is SMTP. If no value is provided, the default value of SMTP is used.
+A text value is optional. The following are the possible values:
+
+* SMTP
+* EX
+
+If no value is provided, the default value of SMTP is used.
   
 ## Remarks
 


### PR DESCRIPTION
A RoutingType value of "EX" has been found in production on multiple Exchange installations.

RoutingType is not defined as an enumeration in types.xsd, according to https://interoperability.blob.core.windows.net/files/MS-OXWSCDATA/%5bMS-OXWSCDATA%5d.pdf

Therefore, I haven't been able to to find out if there are other possible values than these two. Since this value is not enforced via an enumeration in the XSD, in theory *any* value is possible. But EX and SMTP are the two I have actually seen.