### PR TITLE
Update ews-throttling-in-exchange.md

### DIFF
--- a/docs/exchange-web-services/ews-throttling-in-exchange.md
+++ b/docs/exchange-web-services/ews-throttling-in-exchange.md
@@ -234,7 +234,7 @@ The **EWSMaxConcurrency** policy parameter can also be an issue for EWS notifica
 
 If the notification application is multi-threaded and makes simultaneous connection requests to get more information about a particular message that was received by a user account, the **EWSMaxConcurrency** policy limit can be exceeded. To account for this, consider monitoring the concurrent connections in your application, including those that might be used by the server, and implementing request queuing on the client.
 
-The **HangingConnectionLimit** is only applicable to streaming notifications. This limit is set in the web.config file, which means that an Exchange administrator can set this value on an on-premises Exchange server, but Exchange Online mailboxes must use the default value for this limit, which is 3 for both Exchange Online and Exchange 2013. To learn more, see [What throttling values do I need to take into consideration?](how-to-maintain-affinity-between-group-of-subscriptions-and-mailbox-server.md#bk_throttling).
+The **HangingConnectionLimit** is only applicable to streaming notifications. This limit is set in the web.config file, which means that an Exchange administrator can set this value on an on-premises Exchange server, but Exchange Online mailboxes must use the default value for this limit, which is 10 for Exchange Online, Exchange 2019, Exchange 2016 and 3 for Exchange 2013. To learn more, see [What throttling values do I need to take into consideration?](how-to-maintain-affinity-between-group-of-subscriptions-and-mailbox-server.md#bk_throttling).
 
 ## Throttling policy and application performance
 


### PR DESCRIPTION
Modified streaming connection limit to be correct value based on product behavior and https://docs.microsoft.com/en-us/exchange/client-developer/exchange-web-services/how-to-maintain-affinity-between-group-of-subscriptions-and-mailbox-server#what-throttling-values-do-i-need-to-take-into-consideration

Plus I looked in the code ... it is 10.