### PR TITLE
Add missing option in example XML

### DIFF
--- a/docs/web-service-reference/changes-items.md
+++ b/docs/web-service-reference/changes-items.md
@@ -33,6 +33,7 @@ The **Changes** element contains a sequence array of change types that represent
    <Create/>
    <Update/>
    <Delete/>
+   <ReadFlagChange/>
 </Changes>
 ```
 


### PR DESCRIPTION
`ReadFlagChange` is mentioned in the "Child elements" section but not in the example XML.