### PR TITLE
Fix typo in item copy case

### DIFF
--- a/docs/web-service-reference/copiedevent.md
+++ b/docs/web-service-reference/copiedevent.md
@@ -35,7 +35,7 @@ The **CopiedEvent** element represents an event in which an item or folder is co
    <TimeStamp/>
    <ItemId/>
    <ParentFolderId/>
-   <OldFolderId/>
+   <OldItemId/>
    <OldParentFolderId/>
 </CopiedEvent>
 ```


### PR DESCRIPTION
Item copy events will return an OldItemId element, not OldFolderId. See equivalent example in https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/movedevent