### PR TITLE
Update how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md

### DIFF
--- a/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
+++ b/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
@@ -2,7 +2,7 @@
 title: "Authenticate an IMAP, POP or SMTP connection using OAuth"
 description: "Learn how to use OAuth authentication with your IMAP, POP, and SMTP applications."
 author: svpsiva
-ms.date: 02/19/2020
+ms.date: 07/08/2021
 ms.audience: Developer
 ---
 
@@ -26,18 +26,6 @@ You can use the OAuth authentication service provided by Azure Active Directory 
 To use OAuth, an application must be registered with Azure Active Directory.
 
 Follow the instructions listed in [Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app) to create a new application.
-
-## Configure your application
-
-Follow the instructions listed in [Configure a client application to access web APIs](/azure/active-directory/develop/quickstart-configure-app-access-web-apis)
-
-Make sure to add one or more of the following permission scopes that correspond to the protocols you would like to integrate with. In the **Add a permission** wizard, select **Microsoft Graph** and then **Delegated permissions** to find the following permission scopes listed.
-
-| Protocol  | Permission scope        |
-|-----------|-------------------------|
-| IMAP      | `IMAP.AccessAsUser.All` |
-| POP       | `POP.AccessAsUser.All`  |
-| SMTP AUTH | `SMTP.Send`             |
 
 ## Get an access token
 


### PR DESCRIPTION
Configurations described in [Configure a client application to access a web API](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-configure-app-access-web-apis) is not necessary. The applications might not be web apps, and basic configuration is already described in [Register an application with the Microsoft identity platform](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app). Not only that, we cannot use permissions of Microsoft Graph. As described in "Get an access token" section, we need to acquire access tokens of Outlook. And we don't need to add permissions in advance, because we can acquire access tokens dynamically using MSAL or Microsoft Identity Platform v2 endpoint.