### PR TITLE
Fix namespace of Restriction (types -> messages)

### DIFF
--- a/docs/web-service-reference/restriction.md
+++ b/docs/web-service-reference/restriction.md
@@ -69,9 +69,9 @@ The schema that describes this element is located in the EWS virtual directory o
 
 |||
 |:-----|:-----|
-|Namespace  <br/> |https://schemas.microsoft.com/exchange/services/2006/types  <br/> |
-|Schema Name  <br/> |Types schema  <br/> |
-|Validation File  <br/> |Types.xsd  <br/> |
+|Namespace  <br/> |https://schemas.microsoft.com/exchange/services/2006/messages  <br/> |
+|Schema name  <br/> |Messages schema  <br/> |
+|Validation file  <br/> |messages.xsd  <br/> |
 |Can be Empty  <br/> |False  <br/> |
    
 ## See also


### PR DESCRIPTION
It appears the `Restriction` has an incorrect namespace in the documentation. While a `Restriction` element in the `types` namespace may be included as a child of e.g. a `FindFolder` element, it is silently ignored without raising an error. A `Restriction` element in the `messages` namespace, on the other hand, is honored.