### PR TITLE
Document SubscriptionIds element

### DIFF
--- a/docs/web-service-reference/getstreamingevents-operation.md
+++ b/docs/web-service-reference/getstreamingevents-operation.md
@@ -37,7 +37,9 @@ The following example of a **GetStreamingEvents** operation shows how to request
   xmlns:m="https://schemas.microsoft.com/exchange/services/2006/messages">
   <soap:Body>
     <GetStreamingEvents xmlns="https://schemas.microsoft.com/exchange/services/2006/messages">
-      <SubscriptionId>f6bc657d-dde1-4f94-952d-143b95d6483d</SubscriptionId>
+      <SubscriptionIds>
+        <SubscriptionId>f6bc657d-dde1-4f94-952d-143b95d6483d</SubscriptionId>
+      </SubscriptionIds>
       <ConnectionTimeout>30</ConnectionTimeout>
     </GetStreamingEvents>
   </soap:Body>
@@ -50,7 +52,7 @@ The following elements are used in the request:
   
 - [GetStreamingEvents](getstreamingevents.md)
     
-- [SubscriptionId (GetStreamingEvents)](subscriptionid-getstreamingevents.md)
+- [SubscriptionIds](subscriptionids.md)
     
 - [ConnectionTimeout](connectiontimeout.md)
     

--- a/docs/web-service-reference/getstreamingevents.md
+++ b/docs/web-service-reference/getstreamingevents.md
@@ -24,7 +24,9 @@ The **GetStreamingEvents** element represents the operation that is used by clie
   
 ```XML
 <GetStreamingEvents>
-   <SubscriptionId/>
+   <SubscriptionIds>
+     <SubscriptionId/>
+   </SubscriptionIds>
    <ConnectionTimeout/>
 </GetStreamingEvents>
 ```
@@ -42,7 +44,7 @@ None.
 
 |**Element**|**Description**|
 |:-----|:-----|
-|[SubscriptionId (GetStreamingEvents)](subscriptionid-getstreamingevents.md) <br/> |Represents the identifier for a subscription that is queried for events.  <br/> |
+|[SubscriptionIds](subscriptionids.md) <br/> |Contains an array of subscription identifiers that identify the subscriptions to get streaming events for.  <br/> |
 |[ConnectionTimeout](connectiontimeout.md) <br/> |Represents the number of minutes to keep a connection open.  <br/> |
    
 ### Parent elements

--- a/docs/web-service-reference/subscriptionids.md
+++ b/docs/web-service-reference/subscriptionids.md
@@ -1,0 +1,71 @@
+---
+title: "SubscriptionIds"
+ 
+ 
+manager: sethgros
+ms.date: 10/18/2021
+ms.audience: Developer
+ms.topic: reference
+ms.prod: office-online-server
+ms.localizationpriority: medium
+api_name:
+- SubscriptionIds
+api_type:
+- schema
+ms.assetid: 
+description: "The SubscriptionIds element contains an array of subscription identifiers that identify the subscriptions to get streaming events for."
+---
+
+# SubscriptionIds
+
+The **SubscriptionIds** element contains an array of subscription identifiers that identify the subscriptions to get streaming events for. 
+
+```XML
+<SubscriptionIds>
+   <SubscriptionId/>
+</SubscriptionIds>
+```
+
+ **NonEmptyArrayOfSubscriptionIdsType**
+## Attributes and elements
+
+The following sections describe attributes, child elements, and parent elements.
+  
+### Attributes
+
+None.
+  
+### Child elements
+
+|**Element**|**Description**|
+|:-----|:-----|
+|[SubscriptionId (GetStreamingEvents)](subscriptionid-getstreamingevents.md) <br/> |Represents the identifier for a subscription that is queried for events.  <br/> |
+   
+### Parent elements
+
+|**Element**|**Description**|
+|:-----|:-----|
+|[GetStreamingEvents](getstreamingevents.md) <br/> |Represents the operation that is used by clients to request streaming notifications from the server.  <br/> |
+   
+## Text value
+
+None.
+  
+## Remarks
+
+The schema that describes this element is located in the IIS virtual directory that hosts Exchange Web Services.
+  
+## Element information
+
+|||
+|:-----|:-----|
+|Namespace  <br/> |https://schemas.microsoft.com/exchange/services/2006/messages  <br/> |
+|Schema Name  <br/> |Message schema  <br/> |
+|Validation File  <br/> |Messages.xsd  <br/> |
+|Can be Empty  <br/> |False  <br/> |
+
+## See also
+
+[GetStreamingEvents operation](getstreamingevents-operation.md)
+
+- [EWS XML elements in Exchange](ews-xml-elements-in-exchange.md)


### PR DESCRIPTION
Fixes #123

I left `ms.assetid` empty because I don't know the correct value for this attribute.