### PR TITLE
Add missing Transition child element

### DIFF
--- a/docs/web-service-reference/transition.md
+++ b/docs/web-service-reference/transition.md
@@ -45,6 +45,7 @@ None.
 
 |**Element**|**Description**|
 |:-----|:-----|
+|[TransitionsGroup](transitionsgroup.md) <br/> |Represents a collection of time zone transitions.  <br/> |
 |[Transitions](transitions.md) <br/> |Represents a collection of time zone transitions.  <br/> |
    
 ## Remarks

--- a/docs/web-service-reference/transitionsgroup.md
+++ b/docs/web-service-reference/transitionsgroup.md
@@ -22,6 +22,7 @@ The **TransitionsGroup** element represents an array of time zone transitions.
   
 ```xml
 <TransitionsGroup Id="">
+   <Transition/>
    <AbsoluteDateTransition/>
    <RecurringDayTransition/>
    <RecurringDateTransition/>
@@ -46,6 +47,7 @@ The following sections describe attributes, child elements, and parent elements.
 |[AbsoluteDateTransition](absolutedatetransition.md) <br/> |Represents a time zone transition that occurs on a specific date and at a specific time.  <br/> |
 |[RecurringDayTransition](recurringdaytransition.md) <br/> |Represents a time zone transition that occurs on the same day each year.  <br/> |
 |[RecurringDateTransition](recurringdatetransition.md) <br/> |Represents a time zone transition that occurs on a specified day of the year.  <br/> |
+|[Transition](transition.md) <br/> |Represents a time zone transition.  <br/> |
    
 ### Parent elements
 


### PR DESCRIPTION
A TransitionGroup is an ArrayOfTransitionsType just like Transitions (https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/transitions) but was missing the Transition child element. types.xsd also documents this child element.