### PR TITLE
Document two missing fields on MeetingRequest

### DIFF
--- a/docs/web-service-reference/meetingrequest.md
+++ b/docs/web-service-reference/meetingrequest.md
@@ -113,6 +113,8 @@ The **MeetingRequest** element represents a meeting request in the Exchange stor
    <MeetingWorkspaceUrl/>
    <NetShowUrl/>
    <EffectiveRights/>
+   <ReceivedBy/>
+   <ReceivedRepresenting/>
    <LastModifiedName/>
    <LastModifiedTime/>
    <IsAssociated/>
@@ -227,6 +229,8 @@ None.
 |[MeetingWorkspaceUrl](meetingworkspaceurl.md) <br/> |Contains the URL for the meeting workspace that is linked to by the calendar item.  <br/> |
 |[NetShowUrl](netshowurl.md) <br/> |Specifies the URL for a Microsoft Netshow online meeting.  <br/> |
 |[EffectiveRights](effectiverights.md) <br/> |Contains the rights of the client based on the permission settings for the item or folder. This element is read-only.  <br/> |
+|[ReceivedBy](receivedby.md) <br/> |Identifies the delegate in a delegate access scenario.  <br/> |
+|[ReceivedRepresenting](receivedrepresenting.md) <br/> |Identifies the principal in a delegate access scenario.  <br/> |
 |[LastModifiedName](lastmodifiedname.md) <br/> |Contains the display name of the last user to modify an item.  <br/> |
 |[LastModifiedTime](lastmodifiedtime.md) <br/> |Indicates when an item was last modified.  <br/> |
 |[IsAssociated](isassociated.md) <br/> |Indicates whether the item is associated with a folder.  <br/> |


### PR DESCRIPTION
MeetingRequest is referenced in https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/receivedrepresenting and https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/receivedby but not the other way around