### PR TITLE
Fixed missing h2 text errors in exchange-web-services

### DIFF
--- a/docs/exchange-web-services/how-to-create-appointments-in-a-specific-time-zone-by-using-ews-in-exchange.md
+++ b/docs/exchange-web-services/how-to-create-appointments-in-a-specific-time-zone-by-using-ews-in-exchange.md
@@ -218,9 +218,7 @@ The following example [CreateItem operation](https://msdn.microsoft.com/library/
 </soap:Envelope>
 ```
 
-When the three appointments created by the previous EWS example requests are viewed from a client configured in the Eastern time zone, they appear at 1:00 PM, 2:00 PM, and 3:00 PM, respectively.
-  
-## 
+When the three appointments created by the previous EWS example requests are viewed from a client configured in the Eastern time zone, they appear at 1:00 PM, 2:00 PM, and 3:00 PM, respectively. 
 
 Now that you know how to create appointments in specific time zones, you might want to [update the time zones on existing appointments](how-to-update-the-time-zone-for-an-appointment-by-using-ews-in-exchange.md) to a different one. 
   

--- a/docs/exchange-web-services/how-to-export-items-by-using-ews-in-exchange.md
+++ b/docs/exchange-web-services/how-to-export-items-by-using-ews-in-exchange.md
@@ -253,7 +253,7 @@ The following example shows the response to a request to get the MIME stream. Th
 </s:Envelope>
 ```
 
-## 
+ 
 <a name="bk_exportfullfidelity"> </a>
 
 After exporting items, you might want to [import items into Exchange](how-to-import-items-by-using-ews-in-exchange.md).

--- a/docs/exchange-web-services/how-to-work-with-hidden-folders-by-using-ews-in-exchange.md
+++ b/docs/exchange-web-services/how-to-work-with-hidden-folders-by-using-ews-in-exchange.md
@@ -345,7 +345,7 @@ The [FolderId](https://msdn.microsoft.com/library/00d14e3e-4365-4f21-8f88-eaeea7
 </s:Envelope>
 ```
 
-## 
+ 
 <a name="bk_findhiddenews"> </a>
 
 After you have hidden or unhidden folders, you might want to get the folder hierarchy or [synchronize the folder hierarchy](how-to-synchronize-folders-by-using-ews-in-exchange.md). The examples that show you how to [get a folder hierarchy by using the EWS Managed API](how-to-work-with-folders-by-using-ews-in-exchange.md#bk_getfolderhierarchyewsma) or [get a folder hierarchy by using EWS](how-to-work-with-folders-by-using-ews-in-exchange.md#bk_getfolderhierarchyews) also indicate which folders in the hierarchy are hidden. 

--- a/docs/exchange-web-services/verifying-the-results-of-an-ews-or-ews-managed-api-call.md
+++ b/docs/exchange-web-services/verifying-the-results-of-an-ews-or-ews-managed-api-call.md
@@ -237,7 +237,7 @@ If the method you called returns a **ServiceResponseCollection**, and the value 
     
 If the information provided by the **ServiceResponse** properties doesn't provide enough information to correct your method call or unblock you, see [Next steps](#bk_nextsteps) to dig up more information on **ErrorCode** values. 
   
-## 
+ 
 <a name="bk_nextsteps"> </a>
 
 You can look up additional troubleshooting information in the following topics:


### PR DESCRIPTION
4 articles in the exchange-web-services docs have extraneous H2 md headers with no text. They have been removed. 

There is a similar error in a different folder and will make separate PR. 