### PR TITLE
Update syncfolderitems.md

### DIFF
--- a/docs/web-service-reference/syncfolderitems.md
+++ b/docs/web-service-reference/syncfolderitems.md
@@ -26,9 +26,13 @@ The **SyncFolderItems** element defines a request to synchronize items in an Exc
    <SyncFolderId/>
    <SyncState/>
    <Ignore/>
-   <MaxChangesReturned/>   <SyncScope/>
+   <MaxChangesReturned/>
+   <SyncScope/>
 </SyncFolderItems>
 ```
+
+> [!NOTE]
+> SyncFolderItems operation is not supported for use against Office 365 Group mailboxes.
 
  **SyncFolderItemsType**
 ## Attributes and elements


### PR DESCRIPTION
Added note regarding use against Office 365 Group mailboxes.

Based on an internal escalation, engineering have stated that SyncFolderItems is not supported for Office 365 Group mailboxes.  I can share the internal bug Ids as required.