### PR TITLE
Update how-to-authenticate-an-imap-pop-smtp-application-by-using-oaut…

### DIFF
--- a/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
+++ b/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
@@ -26,20 +26,6 @@ To use OAuth, an application must be registered with Azure Active Directory.
 
 Follow the instructions listed in [Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app) to create a new application.
 
-Once registered, to grant users delegated permissions to call the APIs, make the following changes.
-1. Assign Microsoft Graph API permissions.
-    1. For the new application registration, go to **API permissions**.
-    1. Select **Add a permission**.
-    1. Select **Microsoft Graph**.
-    1. Select **Delegated permissions**.
-    1. Depending on which protocol will be used, search for **IMAP.AccessAsUser.All**, **SMTP.Send**, or **POP.AccessAsUser.All** and select.
-    1. To save changes, select **Add permissions**.
-    1. If necessary, to grant permissions to your organization select **Grant admin consent**.
-1. Enable user sign-in for Exchange Online.
-    1. In Azure AD, navigate to **Enterprise Applications**.
-    1. Search for Office 365 Exchange Online. Note, you may need to change the filter to **All Applications**.
-    1. Select **Office 365 Exchange Online application** and in the **Properties** for this app, ensure that the **Enable for users to sign-in?** setting is set to *Yes*.
-
 ## Get an access token
 
 You can use one of our [MSAL client libraries](/azure/active-directory/develop/msal-overview) to fetch an access token from your client application.


### PR DESCRIPTION
…h.md

Configurations described in "Register your application" is not necessary. We cannot use permissions of Microsoft Graph for IMAP, POP and SMTP access. As described in "Get an access token" section, we need to acquire access tokens of Outlook, not Microsoft Graph. And we don't need to add permissions in advance, because we can acquire access tokens dynamically using MSAL or Microsoft Identity Platform v2 endpoint.
And, "Enabled for users to sign-in?" setting of "Office 365 Exchange Online" is "Yes" by default. If this setting is "No", no one can use Exchange Online.

I did a similar document update in the following commit last year.  
https://github.com/MicrosoftDocs/office-developer-exchange-docs/commit/47fc6e17c778a3e809d7daedeb811b707c985eac

Though I couldn't find the exact commit which the unnecessary configurations were added, the following commit is suspicious.  
https://github.com/MicrosoftDocs/office-developer-exchange-docs/commit/99aead68a911ed31f1b1856736892747bf0daed4