### PR TITLE
As per the current test with SMTP Oauth 2.0 client credential flow wi…

### DIFF
--- a/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
+++ b/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
@@ -156,6 +156,8 @@ S: -ERR Authentication failure: unknown user name or bad password.
 
 ### SMTP Protocol Exchange
 
+**Note** As per the current test with SMTP Oauth 2.0 client credential flow with non-interactive sign in is not supported.
+
 To authenticate an SMTP server connection, the client must respond with an `AUTH` command in the following format:
 
 ```text


### PR DESCRIPTION
…th non-interactive sign in is not supported.

As per the current test with SMTP Oauth 2.0 client credential flow with non-interactive sign in is not supported.