### PR TITLE
How to use the New-ServicePrincipal

### DIFF
--- a/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
+++ b/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
@@ -222,7 +222,7 @@ If you registered your application in your own tenant using "Accounts in this or
 
 Once your Azure AD application is consented to by a tenant admin, the tenant admin must register your AAD application's service principal in Exchange via Exchange Online PowerShell. This is enabled by the [`New-ServicePrincipal` cmdlet](/powershell/module/exchange/new-serviceprincipal).
 
-To use the New-ServicePrincipal cmdlet you need to have installed the ExchangeOnlineManagement and also connect to your tenant
+To use the New-ServicePrincipal cmdlet, install the ExchangeOnlineManagement and connect to your tenant as shown in the following snippet.
 
 ```text
 Install-Module -Name ExchangeOnlineManagement -allowprerelease

--- a/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
+++ b/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
@@ -230,7 +230,7 @@ Import-module ExchangeOnlineManagement
 Connect-ExchangeOnline -Organization {tenantId}
 ```
 
-If you still get and error running the New-ServicePrincipal Cmdlet after you perform these steps, it is likely due to the fact that the user does'nt have enough permissions in Exchange online to perform the operation. 
+If you still get an error running the New-ServicePrincipal Cmdlet after you perform these steps, it is likely due to the fact that the user does'nt have enough permissions in Exchange online to perform the operation. 
 
 
 The following is an example of registering an Azure AD application's service principal in Exchange:

--- a/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
+++ b/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
@@ -222,11 +222,22 @@ If you registered your application in your own tenant using "Accounts in this or
 
 Once your Azure AD application is consented to by a tenant admin, the tenant admin must register your AAD application's service principal in Exchange via Exchange Online PowerShell. This is enabled by the [`New-ServicePrincipal` cmdlet](/powershell/module/exchange/new-serviceprincipal).
 
+To use the New-ServicePrincipal cmdlet you need to have installed the ExchangeOnlineManagement and also connect to your tenant
+
+```text
+Install-Module -Name ExchangeOnlineManagement -allowprerelease
+Import-module ExchangeOnlineManagement 
+Connect-ExchangeOnline -Organization {tenantId}
+```
+
+If after these steps you still get error running the New-ServicePrincipal Cmdlet, it is probably due to the fact that your user does not have enough permission in the Exchange online to perform the operation. 
+
+
 The following is an example of registering an Azure AD application's service principal in Exchange:
 
 ```text
 New-ServicePrincipal -AppId <APPLICATION_ID> -ServiceId <OBJECT_ID> [-Organization <ORGANIZATION_ID>]
-```
+```text
 
 The tenant admin can find the service principal identifiers referenced above in your AAD application's enterprise application instance on the tenant. You can find the list of the enterprise application instances on the tenant in the **Enterprise applications** blade in the Azure Active Directory view in Azure Portal.
 

--- a/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
+++ b/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
@@ -230,7 +230,7 @@ Import-module ExchangeOnlineManagement
 Connect-ExchangeOnline -Organization {tenantId}
 ```
 
-If after these steps you still get error running the New-ServicePrincipal Cmdlet, it is probably due to the fact that your user does not have enough permission in the Exchange online to perform the operation. 
+If you still get and error running the New-ServicePrincipal Cmdlet after you perform these steps, it is likely due to the fact that the user does'nt have enough permissions in Exchange online to perform the operation. 
 
 
 The following is an example of registering an Azure AD application's service principal in Exchange:

--- a/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
+++ b/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
@@ -237,7 +237,6 @@ The following is an example of registering an Azure AD application's service pri
 
 ```text
 New-ServicePrincipal -AppId <APPLICATION_ID> -ServiceId <OBJECT_ID> [-Organization <ORGANIZATION_ID>]
-```text
 
 The tenant admin can find the service principal identifiers referenced above in your AAD application's enterprise application instance on the tenant. You can find the list of the enterprise application instances on the tenant in the **Enterprise applications** blade in the Azure Active Directory view in Azure Portal.
 

--- a/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
+++ b/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
@@ -237,7 +237,6 @@ The following is an example of registering an Azure AD application's service pri
 
 ```text
 New-ServicePrincipal -AppId <APPLICATION_ID> -ServiceId <OBJECT_ID> [-Organization <ORGANIZATION_ID>]
-
 The tenant admin can find the service principal identifiers referenced above in your AAD application's enterprise application instance on the tenant. You can find the list of the enterprise application instances on the tenant in the **Enterprise applications** blade in the Azure Active Directory view in Azure Portal.
 
 You can get your registered service principal's identifier using the [`Get-ServicePrincipal` cmdlet](/powershell/module/exchange/get-serviceprincipal).


### PR DESCRIPTION
I had some problem running the New-ServicePrincipal because I always got the following errors. 

```
new-serviceprincipal : The term 'new-serviceprincipal' is not recognized as the name of a cmdlet, function, script
file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct
and try again.
```

The error incorrectly lead me to believe that I had to install some PowerShell module, but it turns out that I missed the appropriate permission in the tenant. I think that it will be useful to give a detailed explanation to people that are not so familiar with the exchange online management module.