### PR TITLE
Remove parameter "-organization" from line 247

### DIFF
--- a/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
+++ b/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
@@ -244,7 +244,7 @@ The tenant admin can find the service principal identifiers referenced above in 
 You can get your registered service principal's identifier using the [`Get-ServicePrincipal` cmdlet](/powershell/module/exchange/get-serviceprincipal).
 
 ```text
-Get-ServicePrincipal -Organization <ORGANIZATION_ID> | fl
+Get-ServicePrincipal | fl
 ```
 
 The OBJECT_ID is the Object ID from the Overview page of the Enterprise Application node (Azure Portal) for the application registration. It is **not** the Object ID from the Overview of the App Registrations node. Using the incorrect Object ID will cause an authentication failure.


### PR DESCRIPTION
In line 247, the parameter mentioned in the command should be removed as it is just for internal use only, so, its existence in this article is misleading the article readers who does not have enough experience about Exchange online PowerShell. Here is below the command documentation article that mentions that the parameter "-organization" is for internal use only and it will not work with Exchange online administrators: https://learn.microsoft.com/en-us/powershell/module/exchange/get-serviceprincipal?view=exchange-ps#-organization