### PR TITLE
fielduri.md typo

### DIFF
--- a/docs/web-service-reference/fielduri.md
+++ b/docs/web-service-reference/fielduri.md
@@ -133,7 +133,7 @@ The following sections describe attributes, child elements, and parent elements.
 |meeting:HasBeenProcessed  <br/> |Identifies the **HasBeenProcessed** property.  <br/> |
 |meeting:ResponseType  <br/> |Identifies the **ResponseType** property.  <br/> |
 |meeting:ProposedStart  <br/> |Identifies the **ProposedStart** property.  <br/> |
-|meeting:PropsedEnd  <br/> |Identifies the **ProposedEnd** property.  <br/> |
+|meeting:ProposedEnd  <br/> |Identifies the **ProposedEnd** property.  <br/> |
 |meetingRequest:MeetingRequestType  <br/> |Identifies the **MeetingRequestType** property.  <br/> |
 |meetingRequest:IntendedFreeBusyStatus  <br/> |Identifies the **IntendedFreeBusyStatus** property.  <br/> |
 |meetingRequest:ChangeHighlights  <br/> |Identifies the **ChangeHighlights** property.  <br/> |


### PR DESCRIPTION
Was this intentional? Looks like a typo.
ProposedEnd property: https://learn.microsoft.com/en-us/exchange/client-developer/web-service-reference/proposedend