### PR TITLE
Update how-to-create-appointments-in-a-specific-time-zone-by-using-ew…

### DIFF
--- a/docs/exchange-web-services/how-to-create-appointments-in-a-specific-time-zone-by-using-ews-in-exchange.md
+++ b/docs/exchange-web-services/how-to-create-appointments-in-a-specific-time-zone-by-using-ews-in-exchange.md
@@ -31,7 +31,7 @@ When creating appointments or meetings using the EWS Managed API, you have three
     > [!NOTE]
     > The **EndTimeZone** property is only available when the [ExchangeService.RequestedServerVersion](https://msdn.microsoft.com/library/microsoft.exchange.webservices.data.exchangeservicebase.requestedserverversion%28v=exchg.80%29.aspx) property is set to **Exchange2010** or later. If it is not available, setting the **StartTimeZone** applies to both the start and end times of the appointment. 
   
-In the following example, the EWS Managed API is used to create three appointments. Each appointment is set to start at 1:00 PM two days from now, in an unspecified time zone, and end one hour later. The first appointment is created in the client computer's time zone by using default EWS Managed API behavior. The second is created in the Central time zone by using the **Appointment.StartTimeZone** and **Appointment.EndTimeZone** properties. The third is created in the Mountain time zone by using the **ExchangeService.TimeZone** property. 
+In the following example, the EWS Managed API is used to create three appointments. Each appointment is set to start at 1:00 PM two days from now, in an unspecified time zone, and end one hour later. The first appointment is created in the client computer's time zone by using default EWS Managed API behavior. The second is created in the Central time zone by using the **Appointment.StartTimeZone** and **Appointment.EndTimeZone** properties, in this case we also set the TimeZoneDescription Extended Property to the same value as TimeZone being used. The third is created in the Mountain time zone by using the **ExchangeService.TimeZone** property. 
   
 ```cs
 using Microsoft.Exchange.WebServices.Data;
@@ -70,6 +70,8 @@ static void CreateAppointments(string userEmail, SecureString userPass)
     // Create an appointment in the Central time zone by
     // using the StartTimeZone property.
     // *****************************************************
+    // Extended Property for the TimeZone Description
+    ExtendedPropertyDefinition tzDescription = new ExtendedPropertyDefinition(DefaultExtendedPropertySet.Appointment, 33332, MapiPropertyType.String);
     // Retrieve the Central time zone.
     TimeZoneInfo centralTZ = TimeZoneInfo.FindSystemTimeZoneById("Central Standard Time");
     // Create the appointment.
@@ -83,6 +85,8 @@ static void CreateAppointments(string userEmail, SecureString userPass)
     centralTZAppt.Start = startTime;
     // Set the end time to 2:00 PM on that same day.
     centralTZAppt.End = endTime;
+    // Set the TimeZone Description on the appointment/meeting
+    centralTZAppt.SetExtendedProperty(tzDescription, centralTZ.DisplayName);
     // Save the appointment to the default calendar.
     try
     {
@@ -122,6 +126,8 @@ static void CreateAppointments(string userEmail, SecureString userPass)
     }
 }
 ```
+   > [!NOTE]
+   > In the second example, the TimeZoneDescription Extended Property need to be set to avoid a potention issue when meeting updates are being sent out to enternal recipient. 
 
 When this example is executed on a client computer configured in the Eastern time zone, and the three appointments it creates are viewed from a client configured in the Eastern time zone, they appear at 1:00 PM, 2:00 PM, and 3:00 PM, respectively.
   
@@ -178,6 +184,10 @@ The following example [CreateItem operation](https://msdn.microsoft.com/library/
         <t:CalendarItem>
           <t:Subject>Appointment created using Central time zone</t:Subject>
           <t:Body BodyType="HTML">Time zone: (UTC-06:00) Central Time (US &amp;amp; Canada)</t:Body>
+          <t:ExtendedProperty>
+             <t:ExtendedFieldURI DistinguishedPropertySetId="Appointment" PropertyId="33332" PropertyType="String" />
+             <t:Value>(UTC-06:00) Central Time (US &amp; Canada)</t:Value>
+          </t:ExtendedProperty>
           <t:Start>2014-06-07T18:00:00.000Z</t:Start>
           <t:End>2014-06-07T19:00:00.000Z</t:End>
           <t:StartTimeZone Id="Central Standard Time" />


### PR DESCRIPTION
…s-in-exchange.md

When the second example is used to create meeting requests and the recipient is external, the meeting is created fine the first time. If the meeting is update using OWA or EWS (Without outlook touching the meeting first) the TimeZone Description is updated to UTC and causes the meeting to shift unless we stamp the TimeZone Description extended property, the first time correctly. We do have an associated bug open and can provide reference if needed.