### PR TITLE
Fix breadcrumbs

### DIFF
--- a/docs/breadcrumb/toc.yml
+++ b/docs/breadcrumb/toc.yml
@@ -1,3 +1,3 @@
-- name: Docs
-  tocHref: /
-  topicHref: /
+- name: Microsoft Exchange
+  tocHref: /exchange/
+  topicHref: /exchange/index

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -41,7 +41,6 @@
       "feedback_system": "Standard",
 
       "breadcrumb_path": "/exchange/client-developer/breadcrumb/toc.json",
-      "extendBreadcrumb": true,
       "ms.topic": "conceptual",
 	  "uhfHeaderId": "MSDocsHeader-Dev_Office",
 	   "ms.suite": "office",


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation. 