### PR TITLE
EWS: relax requirements for <Month> element

### DIFF
--- a/docs/web-service-reference/dayorder.md
+++ b/docs/web-service-reference/dayorder.md
@@ -46,7 +46,7 @@ None.
 
 ## Text value
 
-A text value is required. The value for the **DayOrder** element can be 1 through 5. The maximum value for this element can be either 4 or 5, depending on the month and year.
+A text value is required. The value for the **DayOrder** element can be 1 through 5. The maximum value for this element can be either 4 or 5, depending on the month and year. A value of 0 is used in the Timezone–StandardTime–DayOrder and Timezone–DaylightTime–DayOrder elements if the timezone does not observe DST.
   
 ## Remarks
 

--- a/docs/web-service-reference/month.md
+++ b/docs/web-service-reference/month.md
@@ -46,7 +46,7 @@ None.
    
 ## Text value
 
-A text value is required. The value represents the ordinal rank of the month by occurrence and must be a number between 1 and 12. This is a short integer data type.
+A text value is required. The value represents the ordinal rank of the month by occurrence and must be a number between 1 and 12. A value of 0 is used in the Timezone–StandardTime–Month and Timezone–DaylightTime–Month elements if the timezone does not observe DST. This is a short integer data type.
   
 ## Remarks
 


### PR DESCRIPTION
Outlook 2310 (Build 16924.20150 C2R), also self-identifying as "Outlook 2021 MSO (Version 2310 Build 16.0.16924.20054) 64 bit", sends Month=0 in GetUserAvailability requests when the system timezone is UTC+14:00 Kiritimati.