### PR TITLE
EWS: CalendarItemType is not for contact items

### DIFF
--- a/docs/exchange-web-services/property-sets-and-response-shapes-in-ews-in-exchange.md
+++ b/docs/exchange-web-services/property-sets-and-response-shapes-in-ews-in-exchange.md
@@ -53,7 +53,7 @@ The following table lists the default properties that are returned for each item
 |**Property**|**Calendar item**|**Contact item**|**Message item**|**Task item**|
 |:-----|:-----|:-----|:-----|:-----|
 |Body  <br/> |||X(1)  <br/> ||
-|CalendarItemType  <br/> ||x  <br/> |||
+|CalendarItemType  <br/> |x|  <br/> |||
 |CompanyName  <br/> ||x  <br/> |||
 |CompleteName  <br/> ||x  <br/> |||
 |DateTimeCreated  <br/> |||x  <br/> ||


### PR DESCRIPTION
Table 3 "Default item properties" has CalendarItemType listed for contact items. Rectify that mishap. (Table 4 has got it right already).