### PR TITLE
Update how-to-authenticate-an-imap-pop-smtp-application-by-using-oaut…

### DIFF
--- a/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
+++ b/docs/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth.md
@@ -13,9 +13,6 @@ Learn how to use OAuth authentication to connect with IMAP, POP, or SMTP protoco
 
 > OAuth2 support for IMAP, POP, and SMTP protocols as described below is available  for both Microsoft 365 (which includes Office on the web) and Outlook.com users.
 
-> [!IMPORTANT]
-> This documentation uses the [deprecated Outlook REST API scope](/outlook/rest/compare-graph). New applications should use the [Graph REST API Endpoint](/graph/outlook-mail-concept-overview) instead.
-
 If you're not familiar with the OAuth 2.0 protocol, see [OAuth 2.0 protocol on Microsoft identity platform overview](/azure/active-directory/develop/active-directory-v2-protocols). For more information about the Microsoft Authentication Libraries (MSAL), which implement the OAuth 2.0 protocol to authenticate users and access secure APIs, see [MSAL overview](/azure/active-directory/develop/msal-overview).
 
 You can use the OAuth authentication service provided by Microsoft Entra (Microsoft Entra) to enable your application connect with IMAP, POP, or SMTP protocols to access Exchange Online in Office 365. To use OAuth with your application, you need to:


### PR DESCRIPTION
Removed note referring to Outlook REST and Graph, as it is completely unrelated to this article.  IMAP, POP3 and SMTP are mail protocols (while REST and Graph are APIs).  The scopes detailed in the article are correct.

Original change was in this commit: 
https://github.com/MicrosoftDocs/office-developer-exchange-docs/commit/a1aa392570eaf539924297feb9ec3736070f506d

I couldn't find the referenced employee internally, so couldn't find the context for the note.